### PR TITLE
Update syntax for FHIR version in Meta.source extension

### DIFF
--- a/input/examples/TreatmentDirective-Topicus.json
+++ b/input/examples/TreatmentDirective-Topicus.json
@@ -4,7 +4,7 @@
     "meta": {
         "extension": [
             {
-                "url": "http://hl7.org/fhir/R4/StructureDefinition/extension-Meta.source",
+                "url": "http://hl7.org/fhir/4.0/StructureDefinition/extension-Meta.source",
                 "valueUri": "uri:oid:2.16.840.1.113883.2.4.3.164.2.1.2"
             }
         ],

--- a/input/images-source/Zorgviewer-seq-3.plantuml
+++ b/input/images-source/Zorgviewer-seq-3.plantuml
@@ -53,7 +53,7 @@ loop voor iedere zorgaanbieder
   note right Bron
 "meta": {
     "extension": [ {
-        "url": "http://hl7.org/fhir/R4/StructureDefinition/extension-Meta.source",
+        "url": "http://hl7.org/fhir/4.0/StructureDefinition/extension-Meta.source",
         "valueUri": "uri:oid:2.16.840.1.113883.2.4.3.8"
     } ]
 }
@@ -84,7 +84,7 @@ via Patient.managingOrganization.identifier
     note right Bron
 "meta": {
     "extension": [ {
-        "url": "http://hl7.org/fhir/R4/StructureDefinition/extension-Meta.source",
+        "url": "http://hl7.org/fhir/4.0/StructureDefinition/extension-Meta.source",
         "valueUri": "uri:oid:2.16.840.1.113883.2.4.3.8"
     } ]
 }

--- a/input/includes/bronsysteem-herkennen.md
+++ b/input/includes/bronsysteem-herkennen.md
@@ -6,7 +6,7 @@ Toevoegen aan elke response, dus per resource (bij een read) of per Bundle (bij 
 ```json
 "meta": {
     "extension": [ {
-        "url": "http://hl7.org/fhir/R4/StructureDefinition/extension-Meta.source",
+        "url": "http://hl7.org/fhir/4.0/StructureDefinition/extension-Meta.source",
         "valueUri": "uri:oid:2.16.840.1.113883.2.4.3.8"
     } ]
 }

--- a/input/pagecontent/StructureDefinition-AdvanceDirective-intro.md
+++ b/input/pagecontent/StructureDefinition-AdvanceDirective-intro.md
@@ -22,7 +22,7 @@ Kolom definities:
   <tbody>
     <tr>
       <td>Bron</td>
-      <td><samp>.meta.extension[system="http://hl7.org/fhir/R4/StructureDefinition/extension-Meta.source"].valueUri</samp></td>
+      <td><samp>.meta.extension[system="http://hl7.org/fhir/4.0/StructureDefinition/extension-Meta.source"].valueUri</samp></td>
       <td><code>string</code></td>
       <td><i>nvt</i></td>
       <td> of lookup adhv code (AGB-Z of OID)</td>

--- a/input/pagecontent/StructureDefinition-Condition-intro.md
+++ b/input/pagecontent/StructureDefinition-Condition-intro.md
@@ -25,7 +25,7 @@ Kolom definities:
   <tbody>
     <tr>
       <td>Bron</td>
-      <td><samp>.meta.extension[system="http://hl7.org/fhir/R4/StructureDefinition/extension-Meta.source"].valueUri</samp></td>
+      <td><samp>.meta.extension[system="http://hl7.org/fhir/4.0/StructureDefinition/extension-Meta.source"].valueUri</samp></td>
       <td><code>string</code></td>
       <td><i>nvt</i></td>
       <td>Lookup adhv uri (AGB-Z of OID) <code>&lt;adressering-base&gt;/Organization?identifier=&lt;.meta.tag.code&gt;</code> en gebruik dan <code>Organization.name</code></td>

--- a/input/pagecontent/StructureDefinition-DocumentReference-intro.md
+++ b/input/pagecontent/StructureDefinition-DocumentReference-intro.md
@@ -17,7 +17,7 @@ Kolom definities:
   <tbody>
     <tr>
       <td>Bron</td>
-      <td><samp>.meta.extension[system="http://hl7.org/fhir/R4/StructureDefinition/extension-Meta.source"].valueUri</samp></td>
+      <td><samp>.meta.extension[system="http://hl7.org/fhir/4.0/StructureDefinition/extension-Meta.source"].valueUri</samp></td>
       <td><code>string</code></td>
       <td><i>nvt</i></td>
       <td>Lookup adhv uri (AGB-Z of OID) <code>&lt;adressering-base&gt;/Organization?identifier=&lt;.meta.tag.code&gt;</code> en gebruik dan <code>Organization.name</code></td>

--- a/input/pagecontent/StructureDefinition-LaboratoryTestResult-intro.md
+++ b/input/pagecontent/StructureDefinition-LaboratoryTestResult-intro.md
@@ -21,7 +21,7 @@ Kolom definities:
   <tbody>
     <tr>
       <td>Bron</td>
-      <td><samp>.meta.extension[system="http://hl7.org/fhir/R4/StructureDefinition/extension-Meta.source"].valueUri</samp></td>
+      <td><samp>.meta.extension[system="http://hl7.org/fhir/4.0/StructureDefinition/extension-Meta.source"].valueUri</samp></td>
       <td><code>string</code></td>
       <td><i>nvt</i></td>
       <td>Lookup adhv uri (AGB-Z of OID) <code>&lt;adressering-base&gt;/Organization?identifier=&lt;.meta.tag.code&gt;</code> en gebruik dan <code>Organization.name</code></td>

--- a/input/pagecontent/StructureDefinition-Procedure-intro.md
+++ b/input/pagecontent/StructureDefinition-Procedure-intro.md
@@ -21,7 +21,7 @@ Kolom definities:
   <tbody>
     <tr>
       <td>Bron</td>
-      <td><samp>.meta.extension[system="http://hl7.org/fhir/R4/StructureDefinition/extension-Meta.source"].valueUri</samp></td>
+      <td><samp>.meta.extension[system="http://hl7.org/fhir/4.0/StructureDefinition/extension-Meta.source"].valueUri</samp></td>
       <td><code>string</code></td>
       <td><i>nvt</i></td>
       <td>Lookup adhv uri (AGB-Z of OID) <code>&lt;adressering-base&gt;/Organization?identifier=&lt;.meta.tag.code&gt;</code> en gebruik dan <code>Organization.name</code></td>

--- a/input/pagecontent/StructureDefinition-TreatmentDirective-intro.md
+++ b/input/pagecontent/StructureDefinition-TreatmentDirective-intro.md
@@ -41,7 +41,7 @@ Kolom definities:
   <tbody>
     <tr>
       <td>Bron</td>
-      <td><samp>.meta.extension[system="http://hl7.org/fhir/R4/StructureDefinition/extension-Meta.source"].valueUri</samp></td>
+      <td><samp>.meta.extension[system="http://hl7.org/fhir/4.0/StructureDefinition/extension-Meta.source"].valueUri</samp></td>
       <td><code>string</code></td>
       <td><i>nvt</i></td>
       <td>Lookup adhv uri (AGB-Z of OID) <code>&lt;adressering-base&gt;/Organization?identifier=&lt;.meta.tag.code&gt;</code> en gebruik dan <code>Organization.name</code></td>

--- a/input/pagecontent/checklists.md
+++ b/input/pagecontent/checklists.md
@@ -119,7 +119,7 @@ Er moet een backend EMP worden aangemaakt, zie hiervoor de  [Epic Galaxy documen
 	  "id": "...",
       "meta": {
         "extension": [ {
-            "url": "http://hl7.org/fhir/R4/StructureDefinition/extension-Meta.source",
+            "url": "http://hl7.org/fhir/4.0/StructureDefinition/extension-Meta.source",
             "valueUri": "uri:oid:2.16.840.1.113883.2.4.3.8"
         } ]
     } }

--- a/input/profiles/StructureDefinition-extension-Meta.source.json
+++ b/input/profiles/StructureDefinition-extension-Meta.source.json
@@ -1,7 +1,7 @@
 {
     "resourceType": "StructureDefinition",
     "id": "extension-Meta.source",
-    "url": "http://hl7.org/fhir/R4/StructureDefinition/extension-Meta.source",
+    "url": "http://hl7.org/fhir/4.0/StructureDefinition/extension-Meta.source",
     "name": "extension-Meta.source",
     "title": "extension-Meta.source",
     "status": "active",
@@ -22,7 +22,7 @@
             {
                 "id": "Extension.url",
                 "path": "Extension.url",
-                "fixedUri": "http://hl7.org/fhir/R4/StructureDefinition/extension-Meta.source"
+                "fixedUri": "http://hl7.org/fhir/4.0/StructureDefinition/extension-Meta.source"
             },
             {
                 "id": "Extension.value[x]:valueUri",


### PR DESCRIPTION
Per http://hl7.org/fhir/r4/versions.html#extensions the FHIR version should be specified as 4.0.

Apologies for any problems caused with this 😅 